### PR TITLE
Ignore the error thrown when there is nothing to do

### DIFF
--- a/atlasexec/atlas.go
+++ b/atlasexec/atlas.go
@@ -241,6 +241,11 @@ func (c *Client) runCommand(ctx context.Context, args []string, report interface
 		// When the exit code is 1, it means that the command
 		// was executed successfully, and the output is a JSON
 	}
+	// Ignore the error thrown when there is nothing to do
+	if strings.TrimSpace(string(output)) == "No migration files to execute" {
+		return string(output), nil
+	}
+
 	if report != nil {
 		if err := json.Unmarshal(output, report); err != nil {
 			return string(output), fmt.Errorf("atlas: unable to decode the report %w", err)


### PR DESCRIPTION
When running `migrate apply` repeatedly it responds with exit code `1` and an 'error'. This error can be ignored

Without this, it returns a *very* cryptic error message
`atlas: unable to decode the report invalid character 'N' looking for beginning of value"`

`N`, as in `*N*o migration files to execute`

feel free to close this PR, there are likely nicer ways to handle this. For example returning `ErrNothingToDo`,  but it does work for us