### PR TITLE
atlasexec/migrate-lint: added --context and handle exit status code

### DIFF
--- a/atlasexec/atlas.go
+++ b/atlasexec/atlas.go
@@ -325,6 +325,9 @@ func (c *Client) MigrateLint(ctx context.Context, params *MigrateLintParams) (*S
 	return jsonDecode[SummaryReport](c.runCommand(ctx, lintArgs(params), validJSON))
 }
 
+// ErrLint is returned by MigrateLintError when linting errors are detected
+var ErrLint = errors.New("atlasexec: lint errors exist")
+
 // MigrateLintError runs the 'migrate lint' command, the output is written to params.Writer
 func (c *Client) MigrateLintError(ctx context.Context, params *MigrateLintParams) error {
 	r, exitCode, err := c.runCommand(ctx, lintArgs(params))
@@ -342,7 +345,7 @@ func (c *Client) MigrateLintError(ctx context.Context, params *MigrateLintParams
 		return err
 	}
 	if exitCode == 1 {
-		err = fmt.Errorf("atlasexec: lint errors exist")
+		return ErrLint
 	}
 	return err
 }

--- a/atlasexec/atlas_test.go
+++ b/atlasexec/atlas_test.go
@@ -132,6 +132,7 @@ func TestMigrateLint(t *testing.T) {
 			Writer: &buf,
 		})
 		require.ErrorContains(t, err, "lint errors exist")
+		require.ErrorIs(t, err, atlasexec.ErrLint)
 		var raw json.RawMessage
 		require.NoError(t, json.NewDecoder(&buf).Decode(&raw))
 	})
@@ -281,6 +282,7 @@ func TestMigrateLintWithLogin(t *testing.T) {
 			Web:       true,
 		})
 		require.ErrorContains(t, err, "lint errors exist")
+		require.ErrorIs(t, err, atlasexec.ErrLint)
 		found := false
 		for _, query := range payloads {
 			if !strings.Contains(query.Query, "mutation reportMigrationLint") {

--- a/atlasexec/atlas_test.go
+++ b/atlasexec/atlas_test.go
@@ -131,7 +131,7 @@ func TestMigrateLint(t *testing.T) {
 			Latest: 1,
 			Writer: &buf,
 		})
-		require.NoError(t, err)
+		require.ErrorContains(t, err, "lint errors exist")
 		var raw json.RawMessage
 		require.NoError(t, json.NewDecoder(&buf).Decode(&raw))
 	})
@@ -150,62 +150,68 @@ func TestMigrateLint(t *testing.T) {
 }
 
 func TestMigrateLintWithLogin(t *testing.T) {
-	type graphQLQuery struct {
-		Query     string          `json:"query"`
-		Variables json.RawMessage `json:"variables"`
-	}
-	type Dir struct {
-		Name    string `json:"name"`
-		Content string `json:"content"`
-		Slug    string `json:"slug"`
-	}
-	type dirsQueryResponse struct {
-		Data struct {
-			Dirs []Dir `json:"dirs"`
-		} `json:"data"`
-	}
-	token := "123456789"
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "Bearer "+token, r.Header.Get("Authorization"))
-		var query graphQLQuery
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&query))
-		switch {
-		case strings.Contains(query.Query, "mutation reportMigrationLint"):
-			_, err := fmt.Fprintf(w, `{ "data": { "reportMigrationLint": { "url": "https://migration-lint-report-url" } } }`)
-			require.NoError(t, err)
-		case strings.Contains(query.Query, "query dirs"):
-			dir, err := migrate.NewLocalDir("./testdata/migrations")
-			require.NoError(t, err)
-			ad, err := migrate.ArchiveDir(dir)
-			require.NoError(t, err)
-			var resp dirsQueryResponse
-			resp.Data.Dirs = []Dir{{
-				Name:    "test-dir-name",
-				Slug:    "test-dir-slug",
-				Content: base64.StdEncoding.EncodeToString(ad),
-			}}
-			st2bytes, err := json.Marshal(resp)
-			require.NoError(t, err)
-			_, err = fmt.Fprint(w, string(st2bytes))
-			require.NoError(t, err)
+	type (
+		ContextInput struct {
+			Repo   string `json:"repo"`
+			Path   string `json:"path"`
+			Branch string `json:"branch"`
+			Commit string `json:"commit"`
 		}
-	}))
-	t.Cleanup(srv.Close)
-	st := fmt.Sprintf(
-		`atlas { 
-			cloud {	
-				token = %q
-				url = %q
+		migrateLintReport struct {
+			Context *ContextInput `json:"context"`
+		}
+		graphQLQuery struct {
+			Query             string          `json:"query"`
+			Variables         json.RawMessage `json:"variables"`
+			MigrateLintReport struct {
+				migrateLintReport `json:"input"`
 			}
 		}
-		env "test" {}
-		`, token, srv.URL)
-	atlasConfigURL, clean, err := atlasexec.TempFile(st, "hcl")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, clean())
-	})
+		Dir struct {
+			Name    string `json:"name"`
+			Content string `json:"content"`
+			Slug    string `json:"slug"`
+		}
+		dirsQueryResponse struct {
+			Data struct {
+				Dirs []Dir `json:"dirs"`
+			} `json:"data"`
+		}
+	)
+	token := "123456789"
+	handler := func(payloads *[]graphQLQuery) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, "Bearer "+token, r.Header.Get("Authorization"))
+			var query graphQLQuery
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&query))
+			*payloads = append(*payloads, query)
+			switch {
+			case strings.Contains(query.Query, "mutation reportMigrationLint"):
+				_, err := fmt.Fprintf(w, `{ "data": { "reportMigrationLint": { "url": "https://migration-lint-report-url" } } }`)
+				require.NoError(t, err)
+			case strings.Contains(query.Query, "query dirs"):
+				dir, err := migrate.NewLocalDir("./testdata/migrations")
+				require.NoError(t, err)
+				ad, err := migrate.ArchiveDir(dir)
+				require.NoError(t, err)
+				var resp dirsQueryResponse
+				resp.Data.Dirs = []Dir{{
+					Name:    "test-dir-name",
+					Slug:    "test-dir-slug",
+					Content: base64.StdEncoding.EncodeToString(ad),
+				}}
+				st2bytes, err := json.Marshal(resp)
+				require.NoError(t, err)
+				_, err = fmt.Fprint(w, string(st2bytes))
+				require.NoError(t, err)
+			}
+		}
+	}
 	t.Run("Web and Writer params produces an error", func(t *testing.T) {
+		var payloads []graphQLQuery
+		srv := httptest.NewServer(handler(&payloads))
+		t.Cleanup(srv.Close)
+		atlasConfigURL := generateHCL(t, token, srv)
 		c, err := atlasexec.NewClient(".", "atlas")
 		require.NoError(t, err)
 		params := &atlasexec.MigrateLintParams{
@@ -225,31 +231,88 @@ func TestMigrateLintWithLogin(t *testing.T) {
 		require.Nil(t, got)
 	})
 	t.Run("lint parse web output", func(t *testing.T) {
+		var payloads []graphQLQuery
+		srv := httptest.NewServer(handler(&payloads))
+		t.Cleanup(srv.Close)
+		atlasConfigURL := generateHCL(t, token, srv)
 		c, err := atlasexec.NewClient(".", "atlas")
 		require.NoError(t, err)
 		var buf bytes.Buffer
-		require.NoError(t, c.MigrateLintError(context.Background(), &atlasexec.MigrateLintParams{
+		err = c.MigrateLintError(context.Background(), &atlasexec.MigrateLintParams{
 			DevURL:    "sqlite://file?mode=memory",
 			DirURL:    "file://testdata/migrations",
 			ConfigURL: atlasConfigURL,
 			Latest:    1,
 			Writer:    &buf,
 			Web:       true,
-		}))
+		})
+		require.NoError(t, err)
 		require.Equal(t, strings.TrimSpace(buf.String()), "https://migration-lint-report-url")
 	})
 	t.Run("lint uses --base", func(t *testing.T) {
+		var payloads []graphQLQuery
+		srv := httptest.NewServer(handler(&payloads))
+		t.Cleanup(srv.Close)
+		atlasConfigURL := generateHCL(t, token, srv)
 		c, err := atlasexec.NewClient(".", "atlas")
 		require.NoError(t, err)
 		summary, err := c.MigrateLint(context.Background(), &atlasexec.MigrateLintParams{
-			DevURL: "sqlite://file?mode=memory",
-			DirURL: "file://testdata/migrations",
+			DevURL:    "sqlite://file?mode=memory",
+			DirURL:    "file://testdata/migrations",
 			ConfigURL: atlasConfigURL,
 			Base:      "atlas://test-dir-slug",
 		})
 		require.NoError(t, err)
 		require.NotNil(t, summary)
 	})
+	t.Run("lint uses --context", func(t *testing.T) {
+		var payloads []graphQLQuery
+		srv := httptest.NewServer(handler(&payloads))
+		t.Cleanup(srv.Close)
+		atlasConfigURL := generateHCL(t, token, srv)
+		c, err := atlasexec.NewClient(".", "atlas")
+		require.NoError(t, err)
+		err = c.MigrateLintError(context.Background(), &atlasexec.MigrateLintParams{
+			DevURL:    "sqlite://file?mode=memory",
+			DirURL:    "file://testdata/migrations",
+			ConfigURL: atlasConfigURL,
+			Base:      "atlas://test-dir-slug",
+			Context:   `{"repo":"testing-repo", "path":"path/to/dir","branch":"testing-branch", "commit":"sha123"}`,
+			Web:       true,
+		})
+		require.ErrorContains(t, err, "lint errors exist")
+		found := false
+		for _, query := range payloads {
+			if !strings.Contains(query.Query, "mutation reportMigrationLint") {
+				continue
+			}
+			found = true
+			require.NoError(t, json.Unmarshal(query.Variables, &query.MigrateLintReport))
+			require.Equal(t, "testing-branch", query.MigrateLintReport.Context.Branch)
+			require.Equal(t, "sha123", query.MigrateLintReport.Context.Commit)
+			require.Equal(t, "path/to/dir", query.MigrateLintReport.Context.Path)
+			require.Equal(t, "testing-repo", query.MigrateLintReport.Context.Repo)
+		}
+		require.True(t, found)
+	})
+}
+
+func generateHCL(t *testing.T, token string, srv *httptest.Server) string {
+	st := fmt.Sprintf(
+		`atlas { 
+			cloud {	
+				token = %q
+				url = %q
+			}
+		}
+		env "test" {}
+		`, token, srv.URL)
+	atlasConfigURL, clean, err := atlasexec.TempFile(st, "hcl")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, clean())
+	})
+	return atlasConfigURL
 }
 
 func Test_MigrateStatus(t *testing.T) {

--- a/atlasexec/atlas_test.go
+++ b/atlasexec/atlas_test.go
@@ -131,7 +131,6 @@ func TestMigrateLint(t *testing.T) {
 			Latest: 1,
 			Writer: &buf,
 		})
-		require.ErrorContains(t, err, "lint errors exist")
 		require.ErrorIs(t, err, atlasexec.ErrLint)
 		var raw json.RawMessage
 		require.NoError(t, json.NewDecoder(&buf).Decode(&raw))
@@ -281,7 +280,6 @@ func TestMigrateLintWithLogin(t *testing.T) {
 			Context:   `{"repo":"testing-repo", "path":"path/to/dir","branch":"testing-branch", "commit":"sha123"}`,
 			Web:       true,
 		})
-		require.ErrorContains(t, err, "lint errors exist")
 		require.ErrorIs(t, err, atlasexec.ErrLint)
 		found := false
 		for _, query := range payloads {


### PR DESCRIPTION
This change adds --context to MigrateLint.
It's only useful in combination with Web=true, which exposed a new edge case where Atlas returns status code 1 when linting fails.

Indication of linting failure can be observed using the summary when using MigrateLint, but when using Web=true, there is no summary, only a URL.

So this PR also exposes the status code of Migrate Lint when runnning from MigrateLintError