### PR TITLE
atlasexec: expose atlas exit code

### DIFF
--- a/atlasexec/atlas_test.go
+++ b/atlasexec/atlas_test.go
@@ -131,7 +131,7 @@ func TestMigrateLint(t *testing.T) {
 			Latest: 1,
 			Writer: &buf,
 		})
-		require.ErrorContains(t, err, "atlas command exited with 1")
+		require.ErrorContains(t, err, "destructive changes detected")
 		var raw json.RawMessage
 		require.NoError(t, json.NewDecoder(&buf).Decode(&raw))
 	})

--- a/atlasexec/atlas_test.go
+++ b/atlasexec/atlas_test.go
@@ -52,7 +52,7 @@ func Test_MigrateApply(t *testing.T) {
 	got, err := c.MigrateApply(context.Background(), &atlasexec.MigrateApplyParams{
 		Env: "test",
 	})
-	require.EqualError(t, err, `atlasexec: required flag "url" not set`)
+	require.ErrorContains(t, err, `atlasexec: required flag "url" not set`)
 	require.Nil(t, got)
 	// Set the env var and try again
 	os.Setenv("DB_URL", "sqlite://file?_fk=1&cache=shared&mode=memory")
@@ -131,7 +131,7 @@ func TestMigrateLint(t *testing.T) {
 			Latest: 1,
 			Writer: &buf,
 		})
-		require.NoError(t, err)
+		require.ErrorContains(t, err, "atlas command exited with 1")
 		var raw json.RawMessage
 		require.NoError(t, json.NewDecoder(&buf).Decode(&raw))
 	})
@@ -242,8 +242,8 @@ func TestMigrateLintWithLogin(t *testing.T) {
 		c, err := atlasexec.NewClient(".", "atlas")
 		require.NoError(t, err)
 		summary, err := c.MigrateLint(context.Background(), &atlasexec.MigrateLintParams{
-			DevURL: "sqlite://file?mode=memory",
-			DirURL: "file://testdata/migrations",
+			DevURL:    "sqlite://file?mode=memory",
+			DirURL:    "file://testdata/migrations",
 			ConfigURL: atlasConfigURL,
 			Base:      "atlas://test-dir-slug",
 		})


### PR DESCRIPTION
This is part of a multi stage change

- Changing the runCommand, removing validJson from it. This makes things simpler for the next change
- Changing the runCommand so it won't hide the exitCode and remove the special case for error code 1
- Add the --context parameter to MigrateLint so it can be used from `atlas-action`