### PR TITLE
atlasexec: remove extra logging details made by the SDK

### DIFF
--- a/atlasexec/atlas.go
+++ b/atlasexec/atlas.go
@@ -504,7 +504,6 @@ func jsonDecode[T any](r io.Reader, err error) (*T, error) {
 	var dst T
 	if err = json.Unmarshal(buf, &dst); err != nil {
 		return nil, cliError{
-			stderr: "",
 			stdout: string(buf),
 		}
 	}

--- a/atlasexec/atlas_test.go
+++ b/atlasexec/atlas_test.go
@@ -52,7 +52,7 @@ func Test_MigrateApply(t *testing.T) {
 	got, err := c.MigrateApply(context.Background(), &atlasexec.MigrateApplyParams{
 		Env: "test",
 	})
-	require.ErrorContains(t, err, `atlasexec: required flag "url" not set`)
+	require.ErrorContains(t, err, `required flag "url" not set`)
 	require.Nil(t, got)
 	// Set the env var and try again
 	os.Setenv("DB_URL", "sqlite://file?_fk=1&cache=shared&mode=memory")


### PR DESCRIPTION
This change is introduced because we want the github action logs to look as close as possible to the raw output of Atlas