### PR TITLE
recordriver: fix queries not being idempotent

### DIFF
--- a/recordriver/driver.go
+++ b/recordriver/driver.go
@@ -166,7 +166,6 @@ func (r *Response) clone() *Response {
 		copy(c.Data[i], r.Data[i])
 	}
 	return &c
-
 }
 
 // Next is called to populate the next row of data into the provided slice.

--- a/recordriver/driver.go
+++ b/recordriver/driver.go
@@ -157,15 +157,10 @@ func (*Response) Close() error {
 }
 
 func (r *Response) clone() *Response {
-	var c Response
-	c.Cols = make([]string, len(r.Cols))
-	copy(c.Cols, r.Cols)
-	c.Data = make([][]driver.Value, len(r.Data))
-	for i := range r.Data {
-		c.Data[i] = make([]driver.Value, len(r.Data[i]))
-		copy(c.Data[i], r.Data[i])
+	return &Response{
+		Cols: r.Cols[:],
+		Data: r.Data[:],
 	}
-	return &c
 }
 
 // Next is called to populate the next row of data into the provided slice.

--- a/recordriver/driver.go
+++ b/recordriver/driver.go
@@ -141,15 +141,7 @@ func (s *stmt) Query(_ []driver.Value) (driver.Rows, error) {
 	sess := s.session
 	sessions[sess].Queries = append(sessions[sess].Queries, s.query)
 	if resp, ok := sessions[sess].responses[s.query]; ok {
-		var copiedResp Response
-		copiedResp.Cols = make([]string, len(resp.Cols))
-		copy(copiedResp.Cols, resp.Cols)
-		copiedResp.Data = make([][]driver.Value, len(resp.Data))
-		for i := range resp.Data {
-			copiedResp.Data[i] = make([]driver.Value, len(resp.Data[i]))
-			copy(copiedResp.Data[i], resp.Data[i])
-		}
-		return &copiedResp, nil
+		return resp.clone(), nil
 	}
 	return &Response{}, nil
 }
@@ -162,6 +154,19 @@ func (r *Response) Columns() []string {
 // Close closes the rows iterator. It is a noop.
 func (*Response) Close() error {
 	return nil
+}
+
+func (r *Response) clone() *Response {
+	var c Response
+	c.Cols = make([]string, len(r.Cols))
+	copy(c.Cols, r.Cols)
+	c.Data = make([][]driver.Value, len(r.Data))
+	for i := range r.Data {
+		c.Data[i] = make([]driver.Value, len(r.Data[i]))
+		copy(c.Data[i], r.Data[i])
+	}
+	return &c
+
 }
 
 // Next is called to populate the next row of data into the provided slice.

--- a/recordriver/driver.go
+++ b/recordriver/driver.go
@@ -143,15 +143,11 @@ func (s *stmt) Query(_ []driver.Value) (driver.Rows, error) {
 	if resp, ok := sessions[sess].responses[s.query]; ok {
 		var copiedResp Response
 		copiedResp.Cols = make([]string, len(resp.Cols))
-		for i := range resp.Cols {
-			copiedResp.Cols[i] = resp.Cols[i]
-		}
+		copy(copiedResp.Cols, resp.Cols)
 		copiedResp.Data = make([][]driver.Value, len(resp.Data))
 		for i := range resp.Data {
 			copiedResp.Data[i] = make([]driver.Value, len(resp.Data[i]))
-			for j := range resp.Data[i] {
-				copiedResp.Data[i][i] = resp.Data[i][j]
-			}
+			copy(copiedResp.Data[i], resp.Data[i])
 		}
 		return &copiedResp, nil
 	}

--- a/recordriver/driver.go
+++ b/recordriver/driver.go
@@ -141,19 +141,19 @@ func (s *stmt) Query(_ []driver.Value) (driver.Rows, error) {
 	sess := s.session
 	sessions[sess].Queries = append(sessions[sess].Queries, s.query)
 	if resp, ok := sessions[sess].responses[s.query]; ok {
-		var result Response
-		result.Cols = make([]string, len(resp.Cols))
-		for i, _ := range resp.Cols {
-			result.Cols[i] = resp.Cols[i]
+		var copiedResp Response
+		copiedResp.Cols = make([]string, len(resp.Cols))
+		for i := range resp.Cols {
+			copiedResp.Cols[i] = resp.Cols[i]
 		}
-		result.Data = make([][]driver.Value, len(resp.Data))
-		for i, _ := range resp.Data {
-			result.Data[i] = make([]driver.Value, len(resp.Data[i]))
-			for j, _ := range resp.Data[i] {
-				result.Data[i][i] = resp.Data[i][j]
+		copiedResp.Data = make([][]driver.Value, len(resp.Data))
+		for i := range resp.Data {
+			copiedResp.Data[i] = make([]driver.Value, len(resp.Data[i]))
+			for j := range resp.Data[i] {
+				copiedResp.Data[i][i] = resp.Data[i][j]
 			}
 		}
-		return &result, nil
+		return &copiedResp, nil
 	}
 	return &Response{}, nil
 }

--- a/recordriver/driver.go
+++ b/recordriver/driver.go
@@ -141,7 +141,19 @@ func (s *stmt) Query(_ []driver.Value) (driver.Rows, error) {
 	sess := s.session
 	sessions[sess].Queries = append(sessions[sess].Queries, s.query)
 	if resp, ok := sessions[sess].responses[s.query]; ok {
-		return resp, nil
+		var result Response
+		result.Cols = make([]string, len(resp.Cols))
+		for i, _ := range resp.Cols {
+			result.Cols[i] = resp.Cols[i]
+		}
+		result.Data = make([][]driver.Value, len(resp.Data))
+		for i, _ := range resp.Data {
+			result.Data[i] = make([]driver.Value, len(resp.Data[i]))
+			for j, _ := range resp.Data[i] {
+				result.Data[i][i] = resp.Data[i][j]
+			}
+		}
+		return &result, nil
 	}
 	return &Response{}, nil
 }

--- a/recordriver/driver_test.go
+++ b/recordriver/driver_test.go
@@ -16,18 +16,24 @@ func TestDriver(t *testing.T) {
 		Cols: []string{"sqlite_version()"},
 		Data: [][]driver.Value{{"3.30.1"}},
 	})
-	query, err := db.Query("select sqlite_version()")
-	require.NoError(t, err)
-	defer query.Close()
-	for query.Next() {
-		var version string
-		err = query.Scan(&version)
+	for i := 0; i < 3; i++ {
+		query, err := db.Query("select sqlite_version()")
 		require.NoError(t, err)
-		require.Equal(t, "3.30.1", version)
+		defer query.Close()
+		var rows []string
+		for query.Next() {
+			var version string
+			err = query.Scan(&version)
+			require.NoError(t, err)
+			rows = append(rows, version)
+			require.Equal(t, "3.30.1", version)
+		}
+		require.Len(t, rows, 1)
+		hi, ok := Session("t1")
+		require.True(t, ok)
+		require.Len(t, hi.Queries, i+1)
+
 	}
-	hi, ok := Session("t1")
-	require.True(t, ok)
-	require.Len(t, hi.Queries, 1)
 }
 
 func TestInputs(t *testing.T) {


### PR DESCRIPTION
Previously, two calls to the same query would have resulted in a valid result being returned in the first run and an empty result on the second query.

This was happening because when the code was iterating the response, the returned object was shared.

The solution is to make a copy of the response before returning it