### PR TITLE
atlasexec: ensure the given exec path is correct

### DIFF
--- a/atlasexec/atlas.go
+++ b/atlasexec/atlas.go
@@ -146,9 +146,11 @@ const (
 )
 
 // NewClient returns a new Atlas client with the given atlas-cli path.
-func NewClient(workingDir, execPath string) (*Client, error) {
+func NewClient(workingDir, execPath string) (_ *Client, err error) {
 	if execPath == "" {
 		return nil, fmt.Errorf("execPath cannot be empty")
+	} else if execPath, err = exec.LookPath(execPath); err != nil {
+		return nil, fmt.Errorf("looking up atlas-cli: %w", err)
 	}
 	if workingDir != "" {
 		_, err := os.Stat(workingDir)

--- a/atlasexec/atlas_test.go
+++ b/atlasexec/atlas_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -22,6 +23,23 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/require"
 )
+
+func Test_NewClient(t *testing.T) {
+	execPath, err := exec.LookPath("atlas")
+	require.NoError(t, err)
+
+	// Test that we can create a client with a custom exec path.
+	_, err = atlasexec.NewClient(t.TempDir(), execPath)
+	require.NoError(t, err)
+
+	// Atlas-CLI is installed in the PATH.
+	_, err = atlasexec.NewClient(t.TempDir(), "atlas")
+	require.NoError(t, err)
+
+	// Atlas-CLI is not found for the given exec path.
+	_, err = atlasexec.NewClient(t.TempDir(), "/foo/atlas")
+	require.ErrorContains(t, err, `no such file or directory`)
+}
 
 func Test_MigrateApply(t *testing.T) {
 	ec, err := atlasexec.NewWorkingDir(


### PR DESCRIPTION
Close https://github.com/ariga/atlas-go-sdk/issues/42