### PR TITLE
Correctly parse atlas community version

### DIFF
--- a/atlasexec/atlas.go
+++ b/atlasexec/atlas.go
@@ -534,7 +534,7 @@ func (c *Client) MigrateStatus(ctx context.Context, params *MigrateStatusParams)
 	return firstResult(jsonDecode[MigrateStatus](c.runCommand(ctx, args)))
 }
 
-var reVersion = regexp.MustCompile(`^atlas version v(\d+\.\d+.\d+)-?([a-z0-9]*)?`)
+var reVersion = regexp.MustCompile(`^atlas( community)? version v(\d+\.\d+.\d+)-?([a-z0-9]*)?`)
 
 // Version runs the 'version' command.
 func (c *Client) Version(ctx context.Context) (*Version, error) {
@@ -551,11 +551,11 @@ func (c *Client) Version(ctx context.Context) (*Version, error) {
 		return nil, errors.New("unexpected output format")
 	}
 	var sha string
-	if len(v) > 2 {
-		sha = string(v[2])
+	if len(v) > 3 {
+		sha = string(v[3])
 	}
 	return &Version{
-		Version: string(v[1]),
+		Version: string(v[2]),
 		SHA:     sha,
 		Canary:  strings.Contains(string(out), "canary"),
 	}, nil


### PR DESCRIPTION
# Motivation

The `atlas-terraform-provider` fails with the following error when using the Community version of `atlas` with it (v0.8.0):

```
╷
│ Error: Check atlas version failure
│ 
│   with provider["registry.terraform.io/ariga/atlas"],
│   on main.tf line 26, in provider "atlas":
│   26: provider "atlas" {
│ 
│ unexpected output format
╵
```

The implementation of the version check is delegated to the `atlas-go-sdk` which cannot parse the output of `atlas version` when using a community version. This PR fixes the issue.