### PR TITLE
atlasexec: return an migrateApplyError when stderr != nil

### DIFF
--- a/atlasexec/atlas.go
+++ b/atlasexec/atlas.go
@@ -281,7 +281,7 @@ func (c *Client) runCommand(ctx context.Context, args []string) (io.Reader, erro
 	cmd.Env = env.ToSlice()
 	cmd.Stderr = &stderr
 	cmd.Stdout = &stdout
-	if err := cmd.Run(); err != nil {
+	if err := cmd.Run(); err != nil || stderr.Len() > 0 {
 		e := strings.TrimSpace(stderr.String())
 		// Explicit check the stderr for the login error.
 		if e == "Error: command requires 'atlas login'" {


### PR DESCRIPTION
In atlas-action we check the error type when running `migrateApply`:

```go
	runs, err := a.Atlas.MigrateApplySlice(ctx, params)
	if mErr := (&atlasexec.MigrateApplyError{}); errors.As(err, &mErr) {
		// If the error is a MigrateApplyError, we can still get the successful runs.
		runs = mErr.Result
	} else if err != nil {
		return err
	}
```

but currently we dont return the error when `exitCode` is 0 and `stderr` is not empty